### PR TITLE
Add support for ignore_error_codes config argument

### DIFF
--- a/config/mastodon.spc
+++ b/config/mastodon.spc
@@ -14,4 +14,9 @@ connection "mastodon" {
     # `max_toots` (optional) - Defines the maximum number of toots to list in the mastodon toot tables.
     # If not set, the default is 1000. To avoid limiting, set max_toots = -1
     # max_toots = 1000
+
+    # List of additional Mastodon error codes to ignore for all queries.
+    # When encountering these errors, the API call will not be retried and empty results will be returned.
+    # By default, common not found error codes are ignored and will still be ignored even if this argument is not set.
+    # ignore_error_codes = ["403", "AccessDeniedException", "NotAuthorized", "UnauthorizedOperation", "UnrecognizedClientException", "AuthorizationError"]
 }

--- a/mastodon/connection_config.go
+++ b/mastodon/connection_config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type PluginConfig struct {
-	Server      *string `cty:"server"`
-	AccessToken *string `cty:"access_token"`
-	App         *string `cty:"app"`
-	MaxToots    *int    `cty:"max_toots"`
+	Server           *string  `cty:"server"`
+	AccessToken      *string  `cty:"access_token"`
+	App              *string  `cty:"app"`
+	MaxToots         *int     `cty:"max_toots"`
+	IgnoreErrorCodes []string `cty:"ignore_error_codes"`
 }
 
 var default_max_toots = 1000
@@ -28,6 +29,10 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"max_toots": {
 		Type: schema.TypeInt,
+	},
+	"ignore_error_codes": {
+		Type: schema.TypeList,
+		Elem: &schema.Attribute{Type: schema.TypeString},
 	},
 }
 

--- a/mastodon/errors.go
+++ b/mastodon/errors.go
@@ -1,0 +1,27 @@
+package mastodon
+
+import (
+	"context"
+	"strings"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+
+
+// shouldIgnoreErrors:: function which returns an ErrorPredicate for Mastodon API calls
+func shouldIgnoreErrors(notFoundErrors []string) plugin.ErrorPredicateWithContext {
+	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, err error) bool {
+		mastodonConfig := GetConfig(d.Connection)
+
+		// Append error codes mentioned in the "ignore_error_codes" config argument
+		allErrors := append(notFoundErrors, mastodonConfig.IgnoreErrorCodes...)
+		for _, pattern := range allErrors {
+			// handle not found error
+			if strings.Contains(err.Error(), pattern) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/mastodon/plugin.go
+++ b/mastodon/plugin.go
@@ -10,9 +10,11 @@ import (
 
 func Plugin(ctx context.Context) *plugin.Plugin {
 	p := &plugin.Plugin{
-		Name:                     "steampipe-plugin-mastodon",
-		DefaultTransform:         transform.FromJSONTag(),
-		DefaultShouldIgnoreError: isNotFoundError([]string{"404"}),
+		Name:             "steampipe-plugin-mastodon",
+		DefaultTransform: transform.FromJSONTag(),
+		DefaultIgnoreConfig: &plugin.IgnoreConfig{
+			ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"404"}),
+		},
 		ConnectionConfigSchema: &plugin.ConnectionConfigSchema{
 			NewInstance: ConfigInstance,
 			Schema:      ConfigSchema,

--- a/mastodon/utils.go
+++ b/mastodon/utils.go
@@ -77,15 +77,3 @@ func qualifiedStatusUrl(ctx context.Context, url string, id string) (interface{}
 	logger.Debug("qualifiedStatusUrl", "homeServer", homeServer, "server", server, "person", person, "id", id, "qualifiedStatusUrl", qualifiedStatusUrl)
 	return qualifiedStatusUrl, nil
 }
-
-func isNotFoundError(notFoundErrors []string) plugin.ErrorPredicate {
-	return func(err error) bool {
-
-		for _, pattern := range notFoundErrors {
-			if strings.Contains(err.Error(), pattern) {
-				return true
-			}
-		}
-		return false
-	}
-}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
